### PR TITLE
adding all the latest infos

### DIFF
--- a/Heppy/python/HighMassVHbbAnalyzer.py
+++ b/Heppy/python/HighMassVHbbAnalyzer.py
@@ -25,6 +25,103 @@ def Boost(self,boost):
 class HighMassVHbbAnalyzer( Analyzer ):
     '''Analyze VH events
     '''
+    # === Adding ID function for muons ===
+    def isGoodMuon(self,lepton):#self,lepton):
+      if((lepton.isGlobalMuon()) and (lepton.globalTrack().hitPattern().numberOfValidMuonHits()>0) and (lepton.numberOfMatchedStations()>1) and ((lepton.muonBestTrack().ptError()/lepton.muonBestTrack().pt())<0.3) and (fabs(lepton.muonBestTrack().dxy()<0.2 and lepton.muonBestTrack().isNonnull())) and (fabs(lepton.muonBestTrack().dz())<0.5 and lepton.muonBestTrack().isNonnull()) and (lepton.innerTrack().hitPattern().numberOfValidPixelHits()>0) and (lepton.innerTrack().hitPattern().trackerLayersWithMeasurement()>5)):
+        #print "We have a GOOD Muon!"
+        return True
+      else:
+        #print "We have a BAD Muon"
+        return False
+
+    # === Adding ID function for electrons ===
+    def isGoodElectron(self,lepton):#self,lepton):
+     # print "pt ", lepton.pt()
+     # print "EcalDriven ", lepton.ecalDrivenSeed()
+     # print "Eta ", lepton.eta()
+     # print "DEta ", abs(lepton.deltaEtaSuperClusterTrackAtVtx())
+     # print "DPhi ", abs(lepton.deltaPhiSuperClusterTrackAtVtx())
+     # print "HoE ", lepton.hadronicOverEm()
+     # print "2x5 ", lepton.e2x5Max()
+     # print "1x5 ", lepton.e1x5()
+     # print "Depth ",(lepton.dr03EcalRecHitSumEt()+lepton.dr03HcalDepth1TowerSumEt())
+     # #print "RHO ", event.rho()#lepton.bestGsfElectron.gsfTrack().outerMomentum().Rho()#gsfTrack().rho()
+     # #test = 2+0.03*(lepton.pt())+0.28*(lepton.rho())
+     # #print " < ", $test
+     # print "TrackIso ", lepton.dr03TkSumPt() 
+     # print "Inner layer... ", lepton.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)#gsfTrack()
+     # print "dxy ", (abs(lepton.gsfTrack().dxy()))
+     # print "++++++++++++++"
+      if((lepton.pt()>35) and (lepton.ecalDrivenSeed()==True)):#isEcalDriven()==1)):
+        if(abs(lepton.eta())<1.442):                             #Barrel
+           if((abs(lepton.deltaEtaSuperClusterTrackAtVtx())<0.004) and (abs(lepton.deltaPhiSuperClusterTrackAtVtx())<0.06) and (lepton.hadronicOverEm()<(1/lepton.pt())+0.05) and (((lepton.e2x5Max()/lepton.e5x5())>0.94) or ((lepton.e1x5()/lepton.e5x5())>0.83)) and (lepton.dr03TkSumPt()<5) and (lepton.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)<=1) and  (abs(lepton.dxy())<0.02)): #and ((lepton.dr03EcalRecHitSumEt()+lepton.dr03HcalDepth1TowerSumEt())<(2+0.03*(lepton.pt())+0.28*(lepton.rho())))):
+             print "Barrel good ele"
+             return True
+        elif(abs(lepton.eta())>1.566 and abs(lepton.eta())<2.5): #EndCap
+           if((abs(lepton.deltaEtaSuperClusterTrackAtVtx())<0.006) and (abs(lepton.deltaPhiSuperClusterTrackAtVtx())<0.06) and (lepton.hadronicOverEm()<(5/lepton.pt())+0.05) and (lepton.full5x5_sigmaIetaIeta()>0.03) and (lepton.dr03TkSumPt()<5) and (lepton.gsfTrack().hitPattern().numberOfLostHits(ROOT.reco.HitPattern.MISSING_INNER_HITS)<=1) and  (abs(lepton.dxy())<0.05)): #and ((lepton.dr03EcalRecHitSumEt()+lepton.dr03HcalDepth1TowerSumEt())<(2+0.03*(lepton.pt())+0.28*(lepton.rho())))):
+             print "ENDCAP GOOD Ele!"
+             return True
+      else:
+        print "We have a BAD Ele"
+        return False
+      return False
+
+    # === Adding ID function for jets ===
+    def isGoodLooseJet(self,jet):#self,lepton):
+      if(((jet.neutralHadronEnergyFraction()<0.99) and (jet.neutralEmEnergyFraction()<0.99) and ((jet.chargedMultiplicity()+jet.neutralMultiplicity())>1)) and ((abs(jet.eta())<=2.4) and (jet.chargedHadronEnergyFraction()>0) and (jet.chargedMultiplicity()>0) and (jet.chargedEmEnergyFraction()<0.99) or (abs(jet.eta())>2.4)) and (abs(jet.eta())<=3.0)):
+        return True #for |eta|<=3
+      elif((jet.neutralEmEnergyFraction()<0.90) and (jet.neutralMultiplicity()>10) and (abs(jet.eta())>3.0)):
+        return True #for |eta|>3
+      elif((jet.neutralHadronEnergyFraction()<0.99) and (jet.neutralEmEnergyFraction()<0.99) and ((jet.chargedMultiplicity()+jet.neutralMultiplicity())>1)):
+        if(abs(jet.eta())>=-3.0 and abs(jet.eta())<=3.0):
+           return True
+        elif(abs(jet.eta())>=-2.4 and abs(jet.eta())<=2.4):
+          if((jet.chargedHadronEnergyFraction()>0) and (jet.chargedMultiplicity()>0) and (jet.chargedEmEnergyFraction()<0.99)):
+            return True
+          else:
+            return False
+        else:
+          return False
+      else:
+        print "We have a BAD Jet"
+        return False
+
+    def isGoodTightJet(self,jet):#self,lepton):
+      if(((jet.neutralHadronEnergyFraction()<0.90) and (jet.neutralEmEnergyFraction()<0.90) and ((jet.chargedMultiplicity()+jet.neutralMultiplicity())>1)) and ((abs(jet.eta())<=2.4) and (jet.chargedHadronEnergyFraction()>0) and (jet.chargedMultiplicity()>0) and (jet.chargedEmEnergyFraction()<0.99) or (abs(jet.eta())>2.4)) and (abs(jet.eta())<=3.0)):
+        return True #for |eta|<=3
+      elif((jet.neutralEmEnergyFraction()<0.90) and (jet.neutralMultiplicity()>10) and (abs(jet.eta())>3.0)):
+          return True #for |eta|>3
+      elif((jet.neutralHadronEnergyFraction()<0.90) and (jet.neutralEmEnergyFraction()<0.90) and ((jet.chargedMultiplicity()+jet.neutralMultiplicity())>1)):
+        if(abs(jet.eta())>=-3.0 and abs(jet.eta())<=3.0):
+           return True
+        elif(abs(jet.eta())>=-2.4 and abs(jet.eta())<=2.4):
+          if((jet.chargedHadronEnergyFraction()>0) and (jet.chargedMultiplicity()>0) and (jet.chargedEmEnergyFraction()<0.99)):
+            return True
+          else:
+            return False
+        else:
+          return False
+      else:
+        print "We have a BAD Jet"
+        return False
+
+    def isGoodTightLepVetoJet(self,jet):#self,lepton):
+       if(((jet.neutralHadronEnergyFraction()<0.90) and (jet.neutralEmEnergyFraction()<0.90) and ((jet.chargedMultiplicity()+jet.neutralMultiplicity())>1) and (jet.muonEnergyFraction    ()<0.8)) and ((abs(jet.eta())<=2.4) and (jet.chargedHadronEnergyFraction()>0) and (jet.chargedMultiplicity()>0) and (jet.chargedEmEnergyFraction()<0.90) or (abs(jet.eta())>2.4)) and (abs(jet.eta())<=3.0)):
+         return True #for |eta|<=3
+       elif((jet.neutralHadronEnergyFraction()<0.90) and (jet.neutralEmEnergyFraction()<0.90) and ((jet.chargedMultiplicity()+jet.neutralMultiplicity())>1) and (jet.muonEnergyFraction()<0.8)):
+         if(abs(jet.eta())>=-3.0 and abs(jet.eta())<=3.0):
+            return True
+         elif(abs(jet.eta())>=-2.4 and abs(jet.eta())<=2.4):
+           if((jet.chargedHadronEnergyFraction()>0) and (jet.chargedMultiplicity()>0) and (jet.chargedEmEnergyFraction()<0.90)):
+             return True
+           else:
+             return False
+         else:
+           return False
+       else:
+         print "We have a BAD Jet"
+         return False
+
 
     def declareHandles(self):
         super(HighMassVHbbAnalyzer, self).declareHandles()
@@ -116,7 +213,26 @@ class HighMassVHbbAnalyzer( Analyzer ):
         ## Clean Jets from leptons
         leptons = []
         if hasattr(event, 'inclusiveLeptons'):
-           leptons = [ l for l in event.inclusiveLeptons if ( l.pt()>80 and  ( (abs(l.pdgId()) ==13 and l.relIso03<0.4 ) or (abs(l.pdgId())==11 and l.relIso04 <0.4) ) ) ]
+          for l in event.inclusiveLeptons: #added
+            if(abs(l.pdgId())==13): #added
+              print "MUONE" #added
+              #leptons.isMyGoodMuon = self.isGoodMuon(l) #added
+              #event.inclusiveLeptons.isMyGoodMuon = self.isGoodMuon(l) #added
+              l.isMyGoodMuon = self.isGoodMuon(l) #added
+              #self.isMyGoodMuon = self.isGoodMuon(l) #added
+              print "Result", l.isMyGoodMuon #added
+            elif(abs(l.pdgId())==11): #added
+              if(abs(l.eta())<1.442):
+                l.isBarrelEle = True
+                l.isEndCapEle = False
+              elif(abs(l.eta())>1.566 and abs(l.eta())<2.5):
+                l.isBarrelEle = False
+                l.isEndCapEle = True
+              print "Elettrone!"      #added
+              l.isMyGoodElectron = self.isGoodElectron(l)  #added
+              print "Result", l.isMyGoodElectron #added
+        
+          leptons = [ l for l in event.inclusiveLeptons if ( l.pt()>80 and  ( (abs(l.pdgId()) ==13 and l.relIso03<0.4 ) or (abs(l.pdgId())==11 and l.relIso04 <0.4) ) ) ]
               
         if hasattr(event, 'ak08'):
             AK08Jets = [ j for j in event.ak08  ]

--- a/Heppy/python/vhbbobj.py
+++ b/Heppy/python/vhbbobj.py
@@ -18,6 +18,7 @@ leptonTypeVHbb = NTupleObjectType("leptonTypeVHbb", baseObjectTypes = [ leptonTy
     NTupleVariable("chargedHadRelIso03",  lambda x : x.chargedHadronIsoR(0.3)/x.pt(), help="PF Rel Iso, R=0.3, charged hadrons only"),
     NTupleVariable("chargedHadRelIso04",  lambda x : x.chargedHadronIsoR(0.4)/x.pt(), help="PF Rel Iso, R=0.4, charged hadrons only"),
     NTupleVariable("eleSieie",    lambda x : x.full5x5_sigmaIetaIeta() if abs(x.pdgId())==11 else -1., help="sigma IEtaIEta for electrons"),
+    NTupleVariable("e5x5", lambda x : x.e5x5() if abs(x.pdgId())==11 else -1., help="e5x5 for electrons"), #added
     NTupleVariable("e2x5Max",    lambda x : x.e2x5Max() if abs(x.pdgId())==11 else -1., help="e2x5Max for electrons"),
     NTupleVariable("e1x5",    lambda x : x.e1x5() if abs(x.pdgId())==11 else -1., help="e1x5 for electrons"),
     NTupleVariable("isolTrkPt",    lambda x : x.dr03TkSumPt() if abs(x.pdgId())==11 else -1., help="isolTrkPt for electrons"),
@@ -41,6 +42,11 @@ leptonTypeVHbb = NTupleObjectType("leptonTypeVHbb", baseObjectTypes = [ leptonTy
     NTupleVariable("caloCompatibility",      lambda lepton : lepton.caloCompatibility() if abs(lepton.pdgId()) == 13 else 0, help="Calorimetric compatibility"), 
     NTupleVariable("globalTrackChi2",      lambda lepton : lepton.globalTrack().normalizedChi2() if abs(lepton.pdgId()) == 13 and lepton.globalTrack().isNonnull() else 0, help="Global track normalized chi2"), 
     NTupleVariable("nChamberHits", lambda lepton: lepton.globalTrack().hitPattern().numberOfValidMuonHits() if abs(lepton.pdgId()) == 13 and lepton.globalTrack().isNonnull() else -1, help="Number of muon chamber hits (-1 for electrons)"),
+    NTupleVariable("isBarrelEle", lambda x : getattr(x, "isBarrelEle", -1), int, help="Barrel Electron"), #added
+    NTupleVariable("isEndCapEle", lambda x : getattr(x, "isEndCapEle", -1), int, help="EndCap Electron"), #added
+    NTupleVariable("isEcalDriven", lambda x : x.ecalDrivenSeed() if abs(x.pdgId()) == 11 else -1, int, help="is Ecal Driven to cut on ID"), #added
+    NTupleVariable("isMyGoodMuon", lambda x : getattr(x, "isMyGoodMuon", -1), int, help="High Pt muon ID"), #added
+    NTupleVariable("isMyGoodElectron", lambda x : getattr(x, "isMyGoodElectron", -1), int, help="High Pt electron ID"), #added
     NTupleVariable("relPtError", lambda lepton: lepton.muonBestTrack().ptError()/lepton.muonBestTrack().pt() if abs(lepton.pdgId()) == 13 and lepton.muonBestTrack().isNonnull() else -1, help="relative error of muon pt, intended for high pt ID  (-1 for electrons)"),
     NTupleVariable("isPFMuon", lambda lepton: lepton.isPFMuon() if abs(lepton.pdgId()) == 13 else 0, help="1 if muon passes particle flow ID"),
     NTupleVariable("isHighPtMuon", lambda x : x.muonID("POG_ID_HighPt") if abs(x.pdgId()) == 13 else -1, int, help="High pt id for muons"),
@@ -95,6 +101,9 @@ jetTypeVHbb = NTupleObjectType("jet",  baseObjectTypes = [ jetType ], variables 
    # NTupleVariable("mcMatchId",    lambda x : x.mcMatchId,   int, mcOnly=True, help="Match to source from hard scatter (25 for H, 6 for t, 23/24 for W/Z)"),
    # NTupleVariable("puId", lambda x : x.puJetIdPassed, int,     mcOnly=False, help="puId (full MVA, loose WP, 5.3.X training on AK5PFchs: the only thing that is available now)"),
    # NTupleVariable("id",    lambda x : x.jetID("POG_PFID") , int, mcOnly=False,help="POG Loose jet ID"),
+    NTupleVariable("isMyGoodLooseJet", lambda x : getattr(x, "isMyGoodLooseJet", -1), int, help="Loose Jet ID"), #added
+    NTupleVariable("isMyGoodTightJet", lambda x : getattr(x, "isMyGoodTightJet", -1), int, help="Tight Jet ID"), #added
+    NTupleVariable("isMyGoodTightLepVetoJet", lambda x : getattr(x, "isMyGoodTightLepVetoJet", -1), int, help="Tight Lepton Veto ID for jets"), #added
     NTupleVariable("chHEF", lambda x : x.chargedHadronEnergyFraction(), float, mcOnly = False, help="chargedHadronEnergyFraction (relative to uncorrected jet energy)"),
     NTupleVariable("neHEF", lambda x : x.neutralHadronEnergyFraction(), float, mcOnly = False,help="neutralHadronEnergyFraction (relative to uncorrected jet energy)"),
     NTupleVariable("chEmEF", lambda x : x.chargedEmEnergyFraction(), float, mcOnly = False,help="chargedEmEnergyFraction (relative to uncorrected jet energy)"),

--- a/Heppy/test/vhbb.py
+++ b/Heppy/test/vhbb.py
@@ -379,11 +379,12 @@ sequence = [jsonAna,LHEAna,FlagsAna, hbheAna, GenAna,VHGenAna,PUAna,TrigAna,Vert
 from PhysicsTools.Heppy.utils.miniAodFiles import miniAodFiles
 sample = cfg.MCComponent(
     files = [
+    "root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/WprimeToWhToWlephbb_narrow_M-1200_13TeV-madgraph/MINIAODSIM/Asympt50ns_74X_mcRun2_asymptotic50ns_v0-v1/30000/6248D38C-8D76-E511-B243-20CF305B058C.root"
 #'file:68790C43-4971-E511-AFD7-782BCB20E307.root'
 #		"root://cms-xrd-global.cern.ch//store/mc/RunIISpring15MiniAODv2/DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/50000/009AE141-CA6D-E511-A060-002590A3716C.root"
 
 #'root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/WprimeToWhToWlephbb_narrow_M-1200_13TeV-madgraph/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/10000/DE7A5FB2-DC71-E511-9539-001517F8083C.root'
-'file:DE7A5FB2-DC71-E511-9539-001517F8083C.root'
+#'file:DE7A5FB2-DC71-E511-9539-001517F8083C.root'
 #"root://xrootd.unl.edu//store/mc/RunIISpring15MiniAODv2/ZprimeToZhToZinvhbb_narrow_M-1200_13TeV-madgraph/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/30000/8C77EFF8-4771-E511-97BD-B083FED40671.root"
 #"/store/mc/RunIISpring15MiniAODv2/ZprimeToZhToZinvhbb_narrow_M-1200_13TeV-madgraph/MINIAODSIM/74X_mcRun2_asymptotic_v2-v1/30000/8C77EFF8-4771-E511-97BD-B083FED40671.root"
 #		"/scratch/arizzi/00B6C8DE-E76E-E511-AEDE-008CFA000BB8.root" ##ttbar


### PR DESCRIPTION
This commit includes:
- Muon ID (from:  https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideMuonIdRun2#HighPt_Muon)
- Electron ID (from: https://twiki.cern.ch/twiki/bin/viewauth/CMS/HEEPElectronIdentificationRun2#Selection_Cuts_HEEP_V6_0_Recomme)
- Jet ID -loose, tight, tightLepVeto- (https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID#Recommendations_for_13_TeV_data)
- isEcalDriven variable (for electron ID further study...)
- isBarrelEle and isEndCapEle (just for electrons - ranges taken from HEEP twiki)
- e5x5 (always for ID study)
